### PR TITLE
locking to mosdef-gomc 1.4.0 until Mosdef-gomc to update to Numpy>=2.…

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,6 +2,7 @@
 {% set python_max = '3.12' %}
 {% set name = "mosdef-dihedral-fit" %}
 {% set version = "0.1.13" %}
+{% set build_number = "2" %}
 
 package:
   name: {{ name|lower }}
@@ -14,7 +15,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 1
+  number: {{ build_number }}
 
 requirements:
   host:
@@ -24,7 +25,7 @@ requirements:
     - python >={{ python_min }},<{{ python_max }}
     - netcdf4
     - vmd-python
-    - mosdef-gomc >=1.4.0
+    - mosdef-gomc =1.4.0
     - pytest
     - pytest-cov
     - coverage


### PR DESCRIPTION
…3, as vmd-python versions only cover numpy<2 or numpy>2.3, as mosedef currently covers numpy>=2,<2.3

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
